### PR TITLE
Options Page & Popup Style

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -1,4 +1,6 @@
 chrome.runtime.onMessage.addListener((req, sender, sendRes) => {
+  
+  // Popup handling
   if (sender.tab.url.match(/shiftscheduler/) != null) {
     chrome.windows.create({
       url: chrome.runtime.getURL("popup/index.html"),
@@ -7,4 +9,19 @@ chrome.runtime.onMessage.addListener((req, sender, sendRes) => {
       state: "maximized"
     });
   }
+
+  // Options page will send message to reload the connecteam tab
+  if (req.reloadTabs) {
+    // Reload tabs that match the specified URL pattern
+    const urlPattern = /^https:\/\/app\.connecteam\.com\/.*\/shiftscheduler\//;
+
+    chrome.tabs.query({}, function (tabs) {
+      for (const tab of tabs) {
+        if (urlPattern.test(tab.url)) {
+          chrome.tabs.reload(tab.id);
+        }
+      }
+    });
+  }
+
 });

--- a/chromium/index-of-chrome-storage.txt
+++ b/chromium/index-of-chrome-storage.txt
@@ -1,0 +1,20 @@
+Storage context
+	*ModeSet
+	debugModeSet
+	funnyModeSet
+
+Options Page js context
+	*ModeCheckbox
+	debugModeCheckbox.checked
+	funnyModeCheckbox.checked
+
+Options Page HTML context
+	*ModeElem
+	DebugModeElem
+	FunnyModeElem
+
+
+Action context
+	*Mode
+	debugMode
+	funnyMode

--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Connecteam Position View",
-  "version": "1.1",
-  "description": "Adds new buttons that will export the shifts visible in Connecteam scheduling to CSV files",
+  "version": "0.1.1",
+  "description": "Adds position view button and popup. Now fully rendered in the browser.",
   "manifest_version": 3,
   "permissions": ["storage", "tabs", "activeTab", "scripting", "cookies"],
   "host_permissions": ["https://app.connecteam.com/*"],

--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -2,9 +2,14 @@
   "name": "Connecteam Position View",
   "version": "0.1.1",
   "description": "Adds position view button and popup. Now fully rendered in the browser.",
+  
   "manifest_version": 3,
+  
   "permissions": ["storage", "tabs", "activeTab", "scripting", "cookies"],
   "host_permissions": ["https://app.connecteam.com/*"],
+  
+  "options_page": "options.html",
+
   "content_scripts": [
     {
       "matches": ["https://*.connecteam.com/*"],

--- a/chromium/options.html
+++ b/chromium/options.html
@@ -1,0 +1,26 @@
+<!-- options.html -->
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Connecteam Position View Options</title>
+        <script src="options.js">
+        
+        </script>
+    </head>
+    <body>
+        <h1>Connecteam Position View Options</h1>
+        <form>
+
+            <!-- All Settings -->
+            <label for="DebugMode">Debug Mode:</label>
+            <input type="checkbox" id="DebugModeElem"><br><br>
+
+            <label for="DebugMode">Funny Noise Mode:</label>
+            <input type="checkbox" id="FunnyModeElem"><br><br>
+
+            <div class="save-area">
+                <input type="submit" value="Save" id="SaveButtonElem">
+            </div>
+        </form>
+    </body>
+</html>

--- a/chromium/options.js
+++ b/chromium/options.js
@@ -1,0 +1,38 @@
+// Run when page is done loading
+document.addEventListener('DOMContentLoaded', function () {
+
+    // Store the necessary elements on the form page
+    const form = document.querySelector('form');
+    const debugModeCheckbox = document.getElementById('DebugModeElem');
+    const funnyModeCheckbox = document.getElementById('FunnyModeElem');
+
+    // Load the current setting from Chrome Storage and update the field state
+    chrome.storage.sync.get(['debugModeSet', 'funnyModeSet'], function (result) {
+        // Debugmode
+        debugModeCheckbox.checked = result.debugModeSet;
+
+        // Funny boing sound mode
+        funnyModeCheckbox.checked = result.funnyModeSet;
+    });
+
+
+    // Handle saving settings
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+
+        // Store the updated setting in Chrome Storage
+        chrome.storage.sync.set({
+            debugModeSet: debugModeCheckbox.checked,
+            funnyModeSet: debugModeCheckbox.checked
+        });
+
+        // Tell the background script to reload the connecteam page
+        chrome.runtime.sendMessage({ reloadTabs: true });
+        
+        // Put new element on the page indicating the settings are saved
+        saveButton = document.getElementsByClassName("save-area")[0];
+        let saveText = document.createElement("p");
+        saveText.innerText = "Settings Saved!";
+        saveButton.appendChild(saveText);
+    });
+});

--- a/chromium/pageAction.js
+++ b/chromium/pageAction.js
@@ -133,7 +133,7 @@ async function getShifts() {
         courseId: "2881759",
         startDate: startDate.toISOString(),
         endDate: endDate.toISOString(),
-        timezone: "America/Denver",
+        timezone: "UTC",
         _spirit: getCookie("_spirit"),
       }),
       method: "POST",

--- a/chromium/pageAction.js
+++ b/chromium/pageAction.js
@@ -12,6 +12,19 @@ const observer = new MutationObserver(async (mutList) => {
   }
 });
 
+// Get user set options
+let debugMode;
+
+chrome.storage.sync.get(['debugModeSet'], function (result) {
+    debugMode = result.debugModeSet;
+
+    // Log settings
+    console.log("debugMode set to:");
+    console.log(debugMode);
+});
+
+
+
 // Check if the page is the correct one
 const url = document.URL;
 if (url.match(/shiftscheduler/) != null)

--- a/chromium/popup/index.html
+++ b/chromium/popup/index.html
@@ -15,11 +15,11 @@
   </head>
   <body>
     <div id="schedules">
-      <button type="button" id="back" class="navigation">Previous</button>
-      <div id="chart"></div>
-      <button type="button" id="next" class="navigation">Next</button>
+      <button type="button" id="back" class="navigation"><div class="nav-text">Previous</div></button>
+      <div class="chart" id="chart"></div>
+      <button type="button" id="next" class="navigation"><div class="nav-text">Next</div></button>
     </div>
     <br />
-    <button type="button" id="download-chart">Download Schedule as PNG</button>
+    <div class="footer-button"><button class="downloadButton" type="button" id="download-chart">Download Schedule as PNG</button></div>
   </body>
 </html>

--- a/chromium/popup/script.js
+++ b/chromium/popup/script.js
@@ -86,7 +86,7 @@ function createPlot(shifts) {
     },
   ];
 
-  let chartHeight = $("#chart").offsetHeight;
+  //let chartHeight = $("#chart").offsetHeight;
   let chartWidth = $("#chart").offsetWidth;
 
   // Set layout

--- a/chromium/popup/script.js
+++ b/chromium/popup/script.js
@@ -86,9 +86,14 @@ function createPlot(shifts) {
     },
   ];
 
+  let chartHeight = $("#chart").offsetHeight;
+  let chartWidth = $("#chart").offsetWidth;
+
   // Set layout
   const layout = {
     title: `<b>${titleCase(currentDay)} Schedule</b>`,
+    width: chartWidth, //window.screen.availWidth * 0.89,
+    height: window.screen.availHeight * 0.9,
     xaxis: {
       title: "<b>Time</b>",
       type: "date",

--- a/chromium/popup/styles.css
+++ b/chromium/popup/styles.css
@@ -6,14 +6,55 @@ body {
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: space-evenly;
 }
 
 #chart {
-  width: 1000px;
-  height: 750px;
+  width: 90%;
+  height: 90%;
 }
 
 .navigation {
   width: 100px;
+  margin: 5px;
+}
+
+button {
+    height: 40px;
+    font-size: 15px;
+    position: relative;
+    text-align: center;
+    padding: 0 16px;
+    line-height: 0;
+    background: #fff;
+    border: 1px solid #d9d9d9;
+    border-radius: 20px;
+    color: #2998ff;
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+}
+
+
+button:hover:enabled {
+  border: 1px solid #44a6ff;
+}
+
+.downloadButton {
+  text-align: center;
+}
+
+.chart {
+  border: 1px solid #d9d9d9;
+}
+
+.nav-text {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.footer-button {
+  width: 100%;
+  margin: auto;
+  display: flex;
+  justify-content: center;
 }


### PR DESCRIPTION
Adds an options page and necessary logic to get it to work. 
Only has a debugMode checkbox right now, but any options we may need in the future should be put here.
Options page will automatically reload connecteam when saved, and the current option state will be represented on page load.

I also got sidetracked and updated the popup and style info. It now has the connecteam button style, and the chart will adjust to page size. (may need the chart to recreate itself when the user resizes the page, not that important though)